### PR TITLE
keep namespaces while parsing

### DIFF
--- a/src/Html/Renderer/Halogen.purs
+++ b/src/Html/Renderer/Halogen.purs
@@ -11,8 +11,10 @@ module Html.Renderer.Halogen
 import Prelude
 
 import Data.Array as Array
+import Data.List as List
 import Data.Bifunctor (lmap)
 import Data.Either (Either, either)
+import Data.Maybe (maybe, Maybe(Just, Nothing))
 import DOM.HTML.Indexed (HTMLdiv)
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
@@ -22,23 +24,24 @@ import Html.Parser as Parser
 htmlAttributeToProp :: forall r i. HtmlAttribute -> HP.IProp r i
 htmlAttributeToProp (HtmlAttribute k v) = HP.attr (HH.AttrName k) v
 
-elementToHtml :: forall p i. Element -> HH.HTML p i
-elementToHtml ele =
-  HH.element
-    (HH.ElemName ele.name)
-    (Array.fromFoldable $ map htmlAttributeToProp ele.attributes)
-    children
+elementToHtml :: forall p i. Maybe HH.Namespace -> Element -> HH.HTML p i
+elementToHtml maybeNs ele = insertElem (HH.ElemName ele.name) attrs children
   where
-    children = Array.fromFoldable $ nodeToHtml <$> ele.children
+  newNs = case ele.name of
+    "svg" -> Just $ HH.Namespace "http://www.w3.org/2000/svg"
+    _ -> maybeNs
+  insertElem = maybe HH.element HH.elementNS newNs
+  attrs = (Array.fromFoldable $ map htmlAttributeToProp ele.attributes)
+  children = Array.fromFoldable $ nodeToHtml newNs <$> ele.children
 
-nodeToHtml :: forall p i. HtmlNode -> HH.HTML p i
-nodeToHtml (HtmlElement ele) = elementToHtml ele
-nodeToHtml (HtmlText str) = HH.text str
-nodeToHtml (HtmlComment _) = HH.text ""
+nodeToHtml :: forall p i. Maybe HH.Namespace -> HtmlNode -> HH.HTML p i
+nodeToHtml maybeNs (HtmlElement ele) = elementToHtml maybeNs ele
+nodeToHtml maybeNs (HtmlText str) = HH.text str
+nodeToHtml maybeNs (HtmlComment _) = HH.text ""
 
 parse :: forall p i. String -> Either String (Array (HH.HTML p i))
 parse raw =
-  lmap show $ (Array.fromFoldable <<< map nodeToHtml) <$> Parser.parse raw
+  lmap show $ (Array.fromFoldable <<< map (nodeToHtml Nothing)) <$> Parser.parse raw
 
 render_ :: forall p i. String -> HH.HTML p i
 render_ = render []


### PR DESCRIPTION
This PR fixes #14 . It is somewhat dependent on adding other self-closing elements in svg and mathml though as described in #13 . Not sure if that's in scope but it's of course easy to add. For my purpose it works now and I can parse full pandoc generated articles with katex math.