### PR TITLE
Updates for purs v0.15

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,12 +1,10 @@
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
-
-module.exports = {
-  testEnvironment: "jsdom",
-
+export default {
   // An array of directory names to be searched recursively up from the requiring module's location
   moduleDirectories: ["node_modules", "output"],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  testPathIgnorePatterns: ["/node_modules/", "/bower_components/", ".spago"]
+  testPathIgnorePatterns: ["/node_modules/", "/bower_components/", "/\\.spago/"],
+  testEnvironment: "jsdom"
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
+  "type": "module",
   "scripts": {
-    "build": "spago build -u '--strict --stash +RTS -N2 -RTS'",
-    "test": "spago build && jest"
+    "build": "spago build -u '+RTS -N2 -RTS'",
+    "test": "spago build && NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "devDependencies": {
     "jest": "^28.1.0",

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,12 +1,13 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.4-20211005/packages.dhall sha256:2ec351f17be14b3f6421fbba36f4f01d1681e5c7f46e0c981465c4cf222de5be
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220507/packages.dhall
+        sha256:cf54330f3bc1b25a093b69bff8489180c954b43668c81288901a2ec29a08cc64
 
 let extra =
       { jest =
-          { dependencies = [ "effect", "aff", "aff-promise" ]
-          , repo = "https://github.com/nonbili/purescript-jest.git"
-          , version = "v0.5.0"
-          }
+        { dependencies = [ "effect", "aff", "aff-promise" ]
+        , repo = "https://github.com/klntsky/purescript-jest.git"
+        , version = "7feaa5a880fc75002c4eca312993174e7220252b"
+        }
       }
 
 in  upstream // extra

--- a/packages.dhall
+++ b/packages.dhall
@@ -5,8 +5,8 @@ let upstream =
 let extra =
       { jest =
         { dependencies = [ "effect", "aff", "aff-promise" ]
-        , repo = "https://github.com/klntsky/purescript-jest.git"
-        , version = "7feaa5a880fc75002c4eca312993174e7220252b"
+        , repo = "https://github.com/nonbili/purescript-jest.git"
+        , version = "018543987af27db6a3842048b6b3f5ec47609087"
         }
       }
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -8,6 +8,32 @@ let extra =
         , repo = "https://github.com/nonbili/purescript-jest.git"
         , version = "018543987af27db6a3842048b6b3f5ec47609087"
         }
+      , string-parsers =
+        { dependencies =
+          [ "arrays"
+          , "assert"
+          , "bifunctors"
+          , "console"
+          , "control"
+          , "effect"
+          , "either"
+          , "enums"
+          , "foldable-traversable"
+          , "lists"
+          , "maybe"
+          , "minibench"
+          , "nonempty"
+          , "partial"
+          , "prelude"
+          , "strings"
+          , "tailrec"
+          , "transformers"
+          , "unfoldable"
+          ]
+        , repo =
+            "https://github.com/purescript-contrib/purescript-string-parsers.git"
+        , version = "518038cec5e76a1509bab87685e0dae77462d9e1"
+        }
       }
 
 in  upstream // extra

--- a/spago.dhall
+++ b/spago.dhall
@@ -3,13 +3,16 @@
   [ "arrays"
   , "control"
   , "dom-indexed"
-  , "foldable-traversable"
   , "effect"
+  , "either"
+  , "foldable-traversable"
   , "halogen"
+  , "jest"
+  , "lists"
   , "maybe"
   , "prelude"
-  , "psci-support"
-  , "jest"
+  , "string-parsers"
+  , "strings"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/src/Html/Parser.js
+++ b/src/Html/Parser.js
@@ -49,7 +49,7 @@ function walk(treeWalker) {
   return nodes;
 }
 
-exports.parseFromString = elementCtor => attributeCtor => textCtor => commentCtor => input => {
+export const parseFromString = elementCtor => attributeCtor => textCtor => commentCtor => input => {
   function mapNode(node) {
     if (node.type == "element") {
       return elementCtor({

--- a/src/Html/Parser.purs
+++ b/src/Html/Parser.purs
@@ -7,6 +7,17 @@ module Html.Parser
 
 import Prelude
 
+import Control.Alt ((<|>))
+import Control.Lazy (defer)
+import Data.Array as Array
+import Data.Either (Either)
+import Data.List (List)
+import Data.List as List
+import Data.String.CodeUnits (fromCharArray)
+import StringParser (Parser, ParseError, runParser, try)
+import StringParser.CodeUnits (anyChar, regex, skipSpaces, string, whiteSpace)
+import StringParser.Combinators (many, manyTill, option, optional, sepEndBy)
+
 data HtmlNode
   = HtmlElement Element
   | HtmlText String

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,3 +1,3 @@
-const Test = require("Test.Main");
+import { main } from "Test.Main";
 
-Test.main();
+main();


### PR DESCRIPTION
Blocked by https://github.com/nonbili/purescript-jest/pull/3 - need to update `packages.dhall` to point to a new release of `purescript-jest` instead of revision in my fork.