### PR TITLE
Update for PureScript v0.15

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build
         run: |
           cd example
-          yarn add purescript@0.14 spago
+          yarn add purescript@0.15 spago
           yarn build
       - name: Publish
         run: |

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = { presets: ["@babel/preset-env"] };

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,9 @@
 
 module.exports = {
   testEnvironment: "jsdom",
+  transform: {
+      "^.+\\.(js|jsx)$": "babel-jest",
+  },
 
   // An array of directory names to be searched recursively up from the requiring module's location
   moduleDirectories: ["node_modules", "output"],

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "scripts": {
-    "build": "spago build -u '--strict --stash +RTS -N2 -RTS'",
+    "build": "spago build -u '+RTS -N2 -RTS'",
     "test": "spago build && jest"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.18.10",
+    "babel-jest": "^28.1.3",
     "jest": "^28.1.0",
     "jest-environment-jsdom": "^28.1.0"
   }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,11 +1,12 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.4-20211005/packages.dhall sha256:2ec351f17be14b3f6421fbba36f4f01d1681e5c7f46e0c981465c4cf222de5be
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.4-20220808/packages.dhall
+        sha256:60eee64b04ca0013fae3e02a69fc3b176105c6baa2f31865c67cd5f881a412fd
 
 let extra =
       { jest =
           { dependencies = [ "effect", "aff", "aff-promise" ]
           , repo = "https://github.com/nonbili/purescript-jest.git"
-          , version = "v0.5.0"
+          , version = "v1.0.0"
           }
       }
 

--- a/src/Html/Parser.js
+++ b/src/Html/Parser.js
@@ -49,7 +49,7 @@ function walk(treeWalker) {
   return nodes;
 }
 
-exports.parseFromString = elementCtor => attributeCtor => textCtor => commentCtor => input => {
+export const parseFromString = elementCtor => attributeCtor => textCtor => commentCtor => input => {
   function mapNode(node) {
     if (node.type == "element") {
       return elementCtor({


### PR DESCRIPTION
Verified with `npm run test`:

```
> @ test /home/prikhi/Projects/git/purescript-html-parser-halogen
> spago build && jest

[info] Build succeeded.
[warn] None of your project files import modules from some projects that are in the direct dependencies of your project.
These dependencies are unused. To fix this warning, remove the following packages from the list of dependencies in your config:
- psci-support
 PASS  test/main.test.js
  ✓ plain text (4 ms)
  ✓ simple <a> tag (1 ms)
  ✓ html entities (1 ms)
  ✓ tag inside text
  ✓ non breaking space
  ✓ <script> tag (1 ms)
  ✓ should parse right: <iframe></iframe>
  ✓ should parse right: <iframe width ></iframe>
  ✓ should parse right: <iframe width src='//'></iframe>
  ✓ should parse right: <iframe width ="560" ></iframe>
  ✓ should parse right: <iframe width='560' ></iframe>
  ✓ should parse right: <iframe width = "560" ></iframe>
  ✓ should parse right: <iframe width='560' height='315' src='//www.youtube.com/embed/gE6j-Zp323w' frameborder='0' allowfullscreen></iframe>

Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        4.67 s
Ran all test suites.
```